### PR TITLE
Extend the list of ignored HttpExceptions

### DIFF
--- a/ImageResizer.AzureBlobCache/AzureBlobHandler.cs
+++ b/ImageResizer.AzureBlobCache/AzureBlobHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Web;
 using ImageResizer.Caching;
@@ -12,6 +13,7 @@ namespace Forte.ImageResizer.AzureBlobCache
         private readonly IResponseArgs syncResponse;
         private readonly IAsyncResponsePlan asyncResponse;
         private readonly Stream data;
+        private static readonly int[] ignoredHttpExceptionCodes = {-2147023667, -2147024809, -2147023901};
 
         public AzureBlobHandler(IResponseArgs syncResponse, Stream data)
         {
@@ -42,9 +44,10 @@ namespace Forte.ImageResizer.AzureBlobCache
             {
                 await this.data.CopyToAsync(context.Response.OutputStream);
             }
-            catch (HttpException e) when (e.ErrorCode == -2147023667)
+            catch (HttpException e) when (ignoredHttpExceptionCodes.Contains(e.ErrorCode))
             {
-                //ignoring exception The Remote host closed the connection. The error code is 0x800704CD.
+                //ignoring exception The Remote host closed the connection. The error code is X.
+                //where X might be: 0x800703E3, 0x80070057, 0x800704CD
                 //it happens when request is aborted by client
             }
 


### PR DESCRIPTION
Added handling of HRESULT 0x80070057 and 0x800703E3. 

These are different values of exceptions which might be thrown when connection is closed. Which one is thrown depends on phase of handling request in which connection was closed/failed.

All of errors handled here are variants of "The Remote host closed the connection"